### PR TITLE
Add distribute command, break morto into modules

### DIFF
--- a/commands/distribute.js
+++ b/commands/distribute.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { log, runCommandGroup } = require('../lib.js');
+
+function distribute(projects, options) {
+  log('Running distribute...');
+  const env = options.ci ? 'ci' : 'osx';
+
+  Object.keys(projects).forEach((projectName) =>
+    runCommandGroup(projects[projectName], projectName, 'distributeCommands', env)
+  );
+
+  return 0;
+}
+
+module.exports = distribute;

--- a/commands/index.js
+++ b/commands/index.js
@@ -1,0 +1,11 @@
+const setup = require('./setup.js');
+const test = require('./test.js');
+const distribute = require('./distribute.js');
+
+const { trap } = require('../lib.js');
+
+module.exports = {
+  setup: trap(setup),
+  test: trap(test),
+  distribute: trap(distribute),
+};

--- a/commands/setup.js
+++ b/commands/setup.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { log, runCommandGroup } = require('../lib.js');
+
+function setup(projects, options) {
+  log('Running setup...');
+  const env = options.ci ? 'ci' : 'osx';
+
+  Object.keys(projects).forEach((projectName) =>
+    runCommandGroup(projects[projectName], projectName, 'setupCommands', env)
+  );
+
+  return 0;
+}
+
+module.exports = setup;

--- a/commands/test.js
+++ b/commands/test.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+const jmerge = require('junit-merge/lib');
+const path = require('path');
+const { existsSync, writeFileSync } = require('fs');
 const { log, exec } = require('../lib.js');
 
 function test(projects, options, config) {

--- a/commands/test.js
+++ b/commands/test.js
@@ -62,8 +62,7 @@ function test(projects, options, config) {
       if (options.runTestRunners) {
         project.testRunners.forEach((testRunner, index) => {
           log(`[${projectName}] Running testRunner ${index}...`);
-          exitCode = exec(testRunner, project.subDirectory);
-          if (exitCode) throw new Error('testRunner failed');
+          exitCode = exitCode || exec(testRunner, project.subDirectory);
         });
       } else {
         log(`[${projectName}] skipping testRunners...`);
@@ -72,8 +71,7 @@ function test(projects, options, config) {
 
     if (project.fileTestRunner && files.length > 0) {
       log(`[${projectName}] Running fileTestRunner...`);
-      exitCode = exec(`${project.fileTestRunner} ${files.join(' ')}`, project.subDirectory);
-      if (exitCode) throw new Error('fileTestRunner failed');
+      exitCode = exitCode || exec(`${project.fileTestRunner} ${files.join(' ')}`, project.subDirectory);
     }
   });
 
@@ -108,11 +106,9 @@ function test(projects, options, config) {
       }
     });
 
+    if (!exec(`mkdir -p ${path.dirname(options.junitOutput)}`)) throw new Error("Failed to create JUnit output dir.");
+
     const merged = `<?xml version="1.0"?>\n<testsuites>\n${junitTestSuites.join('\n')}</testsuites>\n`;
-
-    exitCode = exec(`mkdir -p ${path.dirname(options.junitOutput)}`);
-    if (exitCode) throw new Error('failed to make junit output dir');
-
     writeFileSync(options.junitOutput, merged);
     log(`Written to ${options.junitOutput}...`);
   }

--- a/commands/test.js
+++ b/commands/test.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+const { log, exec } = require('../lib.js');
+
+function test(projects, options, config) {
+  let exitCode = 0;
+
+  // When we detect parallelism, skip some projects on this machine.
+  if (process.env.CIRCLE_NODE_TOTAL > 1 && process.env.CIRCLE_NODE_INDEX !== undefined) {
+    log(`Parallelism detected; pruning projects that are not on node ${process.env.CIRCLE_NODE_INDEX}...`);
+    let nodeIndex = 0;
+    const projectNames = Object.keys(projects);
+    projectNames.forEach((projectName) => {
+      if (projects[projectName].fileTestRunner) {
+        log(`[${projectName}] contains fileTestRunner, keeping...`);
+      } else {
+        if (nodeIndex === parseInt(process.env.CIRCLE_NODE_INDEX, 10)) {
+          log(`[${projectName}] running on node ${nodeIndex}, keeping...`);
+        } else {
+          log(`[${projectName}] running on node ${nodeIndex}, removing...`);
+          delete projects[projectName];
+        }
+        nodeIndex = (nodeIndex + 1) % process.env.CIRCLE_NODE_TOTAL;
+      }
+    });
+    log(`Running these projects on this node: ${Object.keys(projects).join(', ')}...`);
+  }
+
+  // Parse the files given by CircleCI (which are balanced already).
+  const internalPathsByProject = {};
+  options.files.forEach((fileName) => {
+    const splitFileName = fileName.split(path.sep);
+    const projectName = splitFileName[0];
+    const internalPath = splitFileName.slice(1).join(path.sep);
+
+    if (!internalPath) throw new Error(`Top-level paths not allowed: "${fileName}"`);
+    if (!config.projects[projectName]) throw new Error(`Unknown project: "${projectName}"`);
+
+    internalPathsByProject[projectName] = internalPathsByProject[projectName] || [];
+    internalPathsByProject[projectName].push(internalPath);
+  });
+
+  // Run the tests for the current project.
+  // 1. If a project.fileTestRunner is given, we assume that in circle.yml we have configured
+  //    files for this project, and that CircleCI has passed them in to us, and have balanced them.
+  // 2. Otherwise, we run the `testRunners`.
+  // In both cases we execute things in the context of the project.subDirectory.
+
+  log('Running tests...');
+
+  Object.keys(projects).forEach((projectName) => {
+    const project = projects[projectName];
+    const files = internalPathsByProject[projectName] || [];
+
+    if (project.testRunners && project.fileTestRunner) {
+      throw new Error(`[${projectName}] Cannot have both testRunners and fileTestRunner for same project`);
+    }
+
+    if (project.testRunners) {
+      if (options.runTestRunners) {
+        project.testRunners.forEach((testRunner, index) => {
+          log(`[${projectName}] Running testRunner ${index}...`);
+          exitCode = exec(testRunner, project.subDirectory);
+        });
+      } else {
+        log(`[${projectName}] skipping testRunners...`);
+      }
+    }
+
+    if (project.fileTestRunner && files.length > 0) {
+      log(`[${projectName}] Running fileTestRunner...`);
+      exitCode = exec(`${project.fileTestRunner} ${files.join(' ')}`, project.subDirectory);
+    }
+  });
+
+  // Merge the JUnit XML files, so CircleCI can report and balance tests.
+  if (!options.junitOutput) {
+    log('Skipping JUnit XML merging (no --junitOutput given)...');
+  } else {
+    log('Merging JUnit XML outputs...');
+    const junitTestSuites = [];
+    Object.keys(projects).forEach((projectName) => {
+      const project = projects[projectName];
+      if (project.junitOutput) {
+        const file = path.join(projectName, project.junitOutput);
+        if (!existsSync(file)) {
+          log(`[${projectName}] "${file}" not found, skipping...`);
+          return;
+        }
+
+        log(`[${projectName}] Parsing "${file}"...`);
+        jmerge.getTestsuites(file, (error, result) => {
+          if (error) {
+            throw new Error(`Error merging JUnit XML outputs: ${error}`);
+          } else {
+            junitTestSuites.push(
+              result
+                .replace(/ file="(\.\/)?/g, ` file="${projectName}/`)
+                .replace(/ classname="/g, ` classname="${projectName}.`)
+                .replace(/ name="/g, ` name="[${projectName}] `)
+            );
+          }
+        });
+      }
+    });
+
+    const merged = `<?xml version="1.0"?>\n<testsuites>\n${junitTestSuites.join('\n')}</testsuites>\n`;
+    exitCode = exec(`mkdir -p ${path.dirname(options.junitOutput)}`);
+    writeFileSync(options.junitOutput, merged);
+    log(`Written to ${options.junitOutput}...`);
+  }
+
+  return exitCode;
+}
+
+module.exports = test;

--- a/commands/test.js
+++ b/commands/test.js
@@ -63,6 +63,7 @@ function test(projects, options, config) {
         project.testRunners.forEach((testRunner, index) => {
           log(`[${projectName}] Running testRunner ${index}...`);
           exitCode = exec(testRunner, project.subDirectory);
+          if (exitCode) throw new Error('testRunner failed');
         });
       } else {
         log(`[${projectName}] skipping testRunners...`);
@@ -72,6 +73,7 @@ function test(projects, options, config) {
     if (project.fileTestRunner && files.length > 0) {
       log(`[${projectName}] Running fileTestRunner...`);
       exitCode = exec(`${project.fileTestRunner} ${files.join(' ')}`, project.subDirectory);
+      if (exitCode) throw new Error('fileTestRunner failed');
     }
   });
 
@@ -107,7 +109,10 @@ function test(projects, options, config) {
     });
 
     const merged = `<?xml version="1.0"?>\n<testsuites>\n${junitTestSuites.join('\n')}</testsuites>\n`;
+
     exitCode = exec(`mkdir -p ${path.dirname(options.junitOutput)}`);
+    if (exitCode) throw new Error('failed to make junit output dir');
+
     writeFileSync(options.junitOutput, merged);
     log(`Written to ${options.junitOutput}...`);
   }

--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
 #!/usr/bin/env node
 const commandLineArgs = require('command-line-args');
 const commandLineCommands = require('command-line-commands');
-const jmerge = require('junit-merge/lib');
 const path = require('path');
 const syncRequest = require('sync-request');
 const { execSync } = require('child_process');
-const { existsSync, writeFileSync } = require('fs');
 
 const commands = require('./commands');
 const { log, exec, copy } = require('./lib.js');

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-const colors = require('colors/safe');
 const commandLineArgs = require('command-line-args');
 const commandLineCommands = require('command-line-commands');
 const jmerge = require('junit-merge/lib');
@@ -8,33 +7,13 @@ const syncRequest = require('sync-request');
 const { execSync } = require('child_process');
 const { existsSync, writeFileSync } = require('fs');
 
-// Global exit code. If some execution goes wrong, we exit with an error code,
-// but we also want to continue running so we can collect JUnit XML files and such.
-let exitCode = 0;
+const commands = require('./commands');
+const { log, exec, copy } = require('./lib.js');
 
-// Some helper functions.
-function log(message) {
-  console.log(`${colors.yellow('[morto]')} ${message}`);
-}
-function exec(command, cwd) {
-  const startTime = new Date();
-  log(`[exec] running "${command}" in "/${cwd || ''}"...`);
-  try {
-    execSync(command, { cwd, stdio: 'inherit', stderr: 'inherit' });
-    log(`[exec] finished "${command}" in ${((new Date() - startTime) / 1000).toFixed(2)}s...`);
-  } catch (_) {
-    log(`[exec] ${colors.red('ERROR')} in "${command}" after ${((new Date() - startTime) / 1000).toFixed(2)}s...`);
-    exitCode = 1;
-  }
-}
-function copy(object) {
-  return JSON.parse(JSON.stringify(object));
-}
-
-const { command, argv } = commandLineCommands([null, 'setup', 'test']);
+const { command, argv } = commandLineCommands([null, 'setup', 'test', 'distribute']);
 
 if (command === null) {
-  console.log('Valid options are: "setup", "test".');
+  console.log('Valid options are: "setup", "test", "distribute".');
   process.exit(1);
 }
 
@@ -118,140 +97,7 @@ let projects = {};
   }
 }
 
-// If the command is `setup`, just run project.setupCommands and then bail.
-{
-  if (command === 'setup') {
-    log('Running setup...');
-
-    Object.keys(projects).forEach((projectName) => {
-      const project = projects[projectName];
-      const setupCommands = project.setupCommands || {};
-
-      const setupType = options.ci ? 'ci' : 'osx';
-      const commands = (setupCommands.common || [])
-        .concat(setupCommands[setupType] || []);
-
-      commands.forEach((setupCommand, index) => {
-        log(`[${projectName}] Running setupCommand ${index}...`);
-        exec(setupCommand, project.subDirectory);
-        if (exitCode !== 0) process.exit(exitCode);
-      });
-    });
-    process.exit(exitCode);
-  } else {
-    log('Skipping setup...');
-  }
-}
-
-// When we detect parallelism, skip some projects on this machine.
-{
-  if (process.env.CIRCLE_NODE_TOTAL > 1 && process.env.CIRCLE_NODE_INDEX !== undefined) {
-    log(`Parallelism detected; pruning projects that are not on node ${process.env.CIRCLE_NODE_INDEX}...`);
-    let nodeIndex = 0;
-    const projectNames = Object.keys(projects);
-    projectNames.forEach((projectName) => {
-      if (projects[projectName].fileTestRunner) {
-        log(`[${projectName}] contains fileTestRunner, keeping...`);
-      } else {
-        if (nodeIndex === parseInt(process.env.CIRCLE_NODE_INDEX, 10)) {
-          log(`[${projectName}] running on node ${nodeIndex}, keeping...`);
-        } else {
-          log(`[${projectName}] running on node ${nodeIndex}, removing...`);
-          delete projects[projectName];
-        }
-        nodeIndex = (nodeIndex + 1) % process.env.CIRCLE_NODE_TOTAL;
-      }
-    });
-    log(`Running these projects on this node: ${Object.keys(projects).join(', ')}...`);
-  }
-}
-
-// Parse the files given by CircleCI (which are balanced already).
-const internalPathsByProject = {};
-{
-  options.files.forEach((fileName) => {
-    const splitFileName = fileName.split(path.sep);
-    const projectName = splitFileName[0];
-    const internalPath = splitFileName.slice(1).join(path.sep);
-
-    if (!internalPath) throw new Error(`Top-level paths not allowed: "${fileName}"`);
-    if (!config.projects[projectName]) throw new Error(`Unknown project: "${projectName}"`);
-
-    internalPathsByProject[projectName] = internalPathsByProject[projectName] || [];
-    internalPathsByProject[projectName].push(internalPath);
-  });
-}
-
-// Run the tests for the current project.
-// 1. If a project.fileTestRunner is given, we assume that in circle.yml we have configured
-//    files for this project, and that CircleCI has passed them in to us, and have balanced them.
-// 2. Otherwise, we run the `testRunners`.
-// In both cases we execute things in the context of the project.subDirectory.
-{
-  log('Running tests...');
-  Object.keys(projects).forEach((projectName) => {
-    const project = projects[projectName];
-    const files = internalPathsByProject[projectName] || [];
-
-    if (project.testRunners && project.fileTestRunner) {
-      throw new Error(`[${projectName}] Cannot have both testRunners and fileTestRunner for same project`);
-    }
-
-    if (project.testRunners) {
-      if (options.runTestRunners) {
-        project.testRunners.forEach((testRunner, index) => {
-          log(`[${projectName}] Running testRunner ${index}...`);
-          exec(testRunner, project.subDirectory);
-        });
-      } else {
-        log(`[${projectName}] skipping testRunners...`);
-      }
-    }
-
-    if (project.fileTestRunner && files.length > 0) {
-      log(`[${projectName}] Running fileTestRunner...`);
-      exec(`${project.fileTestRunner} ${files.join(' ')}`, project.subDirectory);
-    }
-  });
-}
-
-// Merge the JUnit XML files, so CircleCI can report and balance tests.
-{
-  if (!options.junitOutput) {
-    log('Skipping JUnit XML merging (no --junitOutput given)...');
-  } else {
-    log('Merging JUnit XML outputs...');
-    const junitTestSuites = [];
-    Object.keys(projects).forEach((projectName) => {
-      const project = projects[projectName];
-      if (project.junitOutput) {
-        const file = path.join(projectName, project.junitOutput);
-        if (!existsSync(file)) {
-          log(`[${projectName}] "${file}" not found, skipping...`);
-          return;
-        }
-
-        log(`[${projectName}] Parsing "${file}"...`);
-        jmerge.getTestsuites(file, (error, result) => {
-          if (error) {
-            log(`Error merging JUnit XML outputs: ${error}`);
-            process.exit(1);
-          } else {
-            junitTestSuites.push(
-              result
-                .replace(/ file="(\.\/)?/g, ` file="${projectName}/`)
-                .replace(/ classname="/g, ` classname="${projectName}.`)
-                .replace(/ name="/g, ` name="[${projectName}] `)
-            );
-          }
-        });
-      }
-    });
-    const merged = `<?xml version="1.0"?>\n<testsuites>\n${junitTestSuites.join('\n')}</testsuites>\n`;
-    exec(`mkdir -p ${path.dirname(options.junitOutput)}`);
-    writeFileSync(options.junitOutput, merged);
-    log(`Written to ${options.junitOutput}...`);
-  }
-}
+// Run the specified command.
+const exitCode = commands[command](projects, options, config);
 
 process.exit(exitCode);

--- a/lib.js
+++ b/lib.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+const colors = require('colors/safe');
+const { execSync } = require('child_process');
+
+function log(message) {
+  console.log(`${colors.yellow('[morto]')} ${message}`);
+}
+
+function exec(command, cwd) {
+  const startTime = new Date();
+  log(`[exec] running "${command}" in "/${cwd || ''}"...`);
+  try {
+    execSync(command, { cwd, stdio: 'inherit', stderr: 'inherit' });
+    log(`[exec] finished "${command}" in ${((new Date() - startTime) / 1000).toFixed(2)}s...`);
+    return 0;
+  } catch (_) {
+    log(`[exec] ${colors.red('ERROR')} in "${command}" after ${((new Date() - startTime) / 1000).toFixed(2)}s...`);
+    return 1;
+  }
+}
+
+function copy(object) {
+  return JSON.parse(JSON.stringify(object));
+}
+
+function trap(fn) {
+  return function(...args) {
+    try {
+      return fn(...args);
+    } catch(e) {
+      log(`[trap] ERROR: ${e.message}`);
+      return 1;
+    }
+  }
+}
+
+function runCommandGroup(project, name, group, env) {
+  const commandGroup = project[group] || {};
+  const commands = (commandGroup.common || []).concat(commandGroup[env] || []);
+
+  commands.forEach((command, index) => {
+    log(`[${name}] Running ${group} ${index}...`);
+    const exitCode = exec(command, project.subDirectory);
+    if (exitCode !== 0) throw new Error(`Command failed in project ${name}: ${command}`);
+  });
+}
+
+module.exports = { log, exec, copy, trap, runCommandGroup };


### PR DESCRIPTION
- adds commands dir
- adds library module
- fixes some global vars
- adds distribute command

as a result of this change, `morto distribute` will run commands listed in `distributeCommands` sections of projects' `.morto.js` files, with the intention of being called from CI after master builds succeed, in order to distribute built versions of projects into staging environments.

core/keystone changes that implement this feature: https://github.com/remix/remix/pull/627


Test plan: manual