### PR TITLE
Add dependencies to Morto

### DIFF
--- a/commands/setup.js
+++ b/commands/setup.js
@@ -2,7 +2,9 @@
 const { log, runCommandGroup } = require('../lib.js');
 
 function setup(projects, options) {
-  log('Running setup...');
+  // TODO(JP): Do something more advanced for Circle CI caching (maybe with
+  // Circle CI 2.0) so we don't have to run all the setup on all containers.
+  log('Running setup (the same on all containers, so caching is straightforward)...');
   const env = options.ci ? 'ci' : 'osx';
 
   Object.keys(projects).forEach((projectName) =>

--- a/commands/setup.js
+++ b/commands/setup.js
@@ -1,15 +1,28 @@
 #!/usr/bin/env node
-const { log, runCommandGroup } = require('../lib.js');
+const { copy, log, runCommandGroup } = require('../lib.js');
 
-function setup(projects, options) {
+function setup(projects, options, config) {
   // TODO(JP): Do something more advanced for Circle CI caching (maybe with
   // Circle CI 2.0) so we don't have to run all the setup on all containers.
   log('Running setup (the same on all containers, so caching is straightforward)...');
   const env = options.ci ? 'ci' : 'osx';
 
-  Object.keys(projects).forEach((projectName) =>
-    runCommandGroup(projects[projectName], projectName, 'setupCommands', env)
-  );
+  const projectsWithTriggers = copy(projects);
+
+  // Add in projects that other projects get triggered by as they can depend
+  // on setup already having happened there.
+  Object.keys(projects).forEach((projectName) => {
+    if (projects[projectName].triggeredByProjects) {
+      projects[projectName].triggeredByProjects.forEach((triggeredByProjectName) => {
+        log(`Using project "${projectName}", so also setting up "${triggeredByProjectName}"...`);
+        projectsWithTriggers[triggeredByProjectName] = config.projects[triggeredByProjectName];
+      });
+    }
+  });
+
+  Object.keys(projectsWithTriggers).forEach((projectName) => {
+    runCommandGroup(config.projects[projectName], projectName, 'setupCommands', env);
+  });
 
   return 0;
 }

--- a/index.js
+++ b/index.js
@@ -97,16 +97,16 @@ let selectedProjects = {};
       const projectSetupGroups = [];
       Object.keys(config.projects).forEach((projectName) => {
         const project = config.projects[projectName];
-        if (project.dependsOnProjects) {
-          project.dependsOnProjects.forEach((dependentProjectName) => {
+        if (project.triggeredByProjects) {
+          project.triggeredByProjects.forEach((dependentProjectName) => {
             if (!config.projects[dependentProjectName]) {
               throw new Error(`Couldn't find project "${dependentProjectName}" that "${projectName}" depends on`);
             }
-            if (config.projects[dependentProjectName].dependsOnProjects) {
+            if (config.projects[dependentProjectName].triggeredByProjects) {
               throw new Error(`"${projectName}" depends on "${dependentProjectName}", which itself depends on other selectedProjects, cannot do that`);
             }
           });
-          projectSetupGroups.push(project.dependsOnProjects.concat([projectName]));
+          projectSetupGroups.push(project.triggeredByProjects.concat([projectName]));
         }
       });
       log(`All project groups for setup: ${projectSetupGroups.map((group) => group.join('+')).join(', ')}...`);
@@ -128,8 +128,8 @@ let selectedProjects = {};
       // If a project is selected, make sure projects that depend on it are selected.
       Object.keys(config.projects).forEach((projectName) => {
         const project = config.projects[projectName];
-        if (project.dependsOnProjects) {
-          project.dependsOnProjects.forEach((dependentProjectName) => {
+        if (project.triggeredByProjects) {
+          project.triggeredByProjects.forEach((dependentProjectName) => {
             if (selectedProjects[dependentProjectName]) {
               log(`Using project "${dependentProjectName}", so also using "${projectName}"...`);
               selectedProjects[dependentProjectName] = config.projects[dependentProjectName];

--- a/index.js
+++ b/index.js
@@ -93,14 +93,13 @@ let selectedProjects = {};
       const project = config.projects[projectName];
       if (project.triggeredByProjects) {
         project.triggeredByProjects.forEach((triggeredByProjectName) => {
+          if (!config.projects[triggeredByProjectName]) {
+            throw new Error(`Couldn't find project "${triggeredByProjectName}" that "${projectName}" gets triggered by`);
+          }
+          if (config.projects[triggeredByProjectName].triggeredByProjects) {
+            throw new Error(`"${projectName}" gets triggered by "${triggeredByProjectName}", which itself is triggered by other projects, cannot do that`);
+          }
           if (selectedProjects[triggeredByProjectName]) {
-            if (!config.projects[triggeredByProjectName]) {
-              throw new Error(`Couldn't find project "${triggeredByProjectName}" that "${projectName}" gets triggered by`);
-            }
-            if (config.projects[triggeredByProjectName].triggeredByProjects) {
-              throw new Error(`"${projectName}" is triggered by "${triggeredByProjectName}", which itself is triggered by other projects, cannot do that`);
-            }
-
             log(`Selected project "${triggeredByProjectName}", so also selecting "${projectName}"...`);
             selectedProjects[projectName] = config.projects[projectName];
           }

--- a/index.js
+++ b/index.js
@@ -98,12 +98,12 @@ let selectedProjects = {};
       Object.keys(config.projects).forEach((projectName) => {
         const project = config.projects[projectName];
         if (project.triggeredByProjects) {
-          project.triggeredByProjects.forEach((dependentProjectName) => {
-            if (!config.projects[dependentProjectName]) {
-              throw new Error(`Couldn't find project "${dependentProjectName}" that "${projectName}" depends on`);
+          project.triggeredByProjects.forEach((triggeredByProjectName) => {
+            if (!config.projects[triggeredByProjectName]) {
+              throw new Error(`Couldn't find project "${triggeredByProjectName}" that "${projectName}" depends on`);
             }
-            if (config.projects[dependentProjectName].triggeredByProjects) {
-              throw new Error(`"${projectName}" depends on "${dependentProjectName}", which itself depends on other selectedProjects, cannot do that`);
+            if (config.projects[triggeredByProjectName].triggeredByProjects) {
+              throw new Error(`"${projectName}" depends on "${triggeredByProjectName}", which itself depends on other selectedProjects, cannot do that`);
             }
           });
           projectSetupGroups.push(project.triggeredByProjects.concat([projectName]));
@@ -129,10 +129,10 @@ let selectedProjects = {};
       Object.keys(config.projects).forEach((projectName) => {
         const project = config.projects[projectName];
         if (project.triggeredByProjects) {
-          project.triggeredByProjects.forEach((dependentProjectName) => {
-            if (selectedProjects[dependentProjectName]) {
-              log(`Using project "${dependentProjectName}", so also using "${projectName}"...`);
-              selectedProjects[dependentProjectName] = config.projects[dependentProjectName];
+          project.triggeredByProjects.forEach((triggeredByProjectName) => {
+            if (selectedProjects[triggeredByProjectName]) {
+              log(`Using project "${triggeredByProjectName}", so also using "${projectName}"...`);
+              selectedProjects[triggeredByProjectName] = config.projects[triggeredByProjectName];
             }
           });
         }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const syncRequest = require('sync-request');
 const { execSync } = require('child_process');
 
 const commands = require('./commands');
-const { log, exec, copy } = require('./lib.js');
+const { log, copy } = require('./lib.js');
 
 const { command, argv } = commandLineCommands([null, 'setup', 'test', 'distribute']);
 


### PR DESCRIPTION
You can now have `dependsOnProjects` set on a project, which should be
an array of project names. Say you have projects "A", "B", and
"A-B-integration" which depends on "A" and "B", then it works like
this:
- During setup, if any of "A", "B", or "A-B-integration" changes, then
we'll setup all three, because we know that "A-B-integration" will be
run and it depends on "A" and "B" being set up.
- During other commands, if any of of "A", "B", or "A-B-integration"
changes, then that project will be run, plus also "A-B-integration".

You currently cannot nest dependencies, so you cannot depend on a
project that itself depends on another project.

Will update the README in a separate PR to get this in quickly to
unblock some problems we're seeing in the remix/remix repo.

Test plan: tested this locally on the remix/remix repo.